### PR TITLE
🏷️ Implement year/month semantic versioning for Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: 🔧 Prepare Assembly Line (Docker Buildx)
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         id: buildx
 
       - name: 🔑 Connect to LEGO Warehouse (Docker Hub)
@@ -44,15 +44,15 @@ jobs:
           
           # Use GitHub run number as patch version for simplicity
           # This ensures each build gets an incrementing patch number
-          PATCH_VERSION=${{ github.run_number }}
+          PATCH_VERSION="${{ github.run_number }}"
           
           # Create semantic version: YY.M.PATCH
           VERSION="${YEAR_MONTH}.${PATCH_VERSION}"
           YEAR_MONTH_TAG="${YEAR_MONTH}"
           
           # Set environment variables for use in subsequent steps
-          echo "version=${VERSION}" >> $GITHUB_ENV
-          echo "year_month=${YEAR_MONTH_TAG}" >> $GITHUB_ENV
+          echo "version=${VERSION}" >> "$GITHUB_ENV"
+          echo "year_month=${YEAR_MONTH_TAG}" >> "$GITHUB_ENV"
           
           echo "🏷️ Building semantic version: ${VERSION}"
           echo "📅 Year/Month tag: ${YEAR_MONTH_TAG}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,17 +36,27 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: 🏷️ Create LEGO Set Version Tag
-        id: tag
+      - name: 🏷️ Generate Semantic Version Tag
+        id: version
         run: |
-          VERSION="v1.0.0"
-          if [ ! -z "${{ github.event.release.tag_name }}" ]; then
-            VERSION=${{ github.event.release.tag_name }}
-          fi
-          DATE_TAG=$(date +'%Y%m%d')
-          VERSION_TAG="${VERSION}-${DATE_TAG}"
-          echo "tag=${VERSION_TAG}" >> $GITHUB_ENV
-          echo "Building LEGO set version: ${VERSION_TAG}"
+          # Generate YY.M format from current date
+          YEAR_MONTH=$(date +'%y.%-m')
+          
+          # Use GitHub run number as patch version for simplicity
+          # This ensures each build gets an incrementing patch number
+          PATCH_VERSION=${{ github.run_number }}
+          
+          # Create semantic version: YY.M.PATCH
+          VERSION="${YEAR_MONTH}.${PATCH_VERSION}"
+          YEAR_MONTH_TAG="${YEAR_MONTH}"
+          
+          # Set environment variables for use in subsequent steps
+          echo "version=${VERSION}" >> $GITHUB_ENV
+          echo "year_month=${YEAR_MONTH_TAG}" >> $GITHUB_ENV
+          
+          echo "🏷️ Building semantic version: ${VERSION}"
+          echo "📅 Year/Month tag: ${YEAR_MONTH_TAG}"
+          echo "🔢 Run number: ${PATCH_VERSION}"
 
       - name: 🔧 Prepare LEGO Pieces (Backend Dependencies)
         if: matrix.service == 'backend'
@@ -54,7 +64,7 @@ jobs:
           pip install --upgrade pip
           pip install -r backend/requirements.txt
 
-      - name: 🏢 Assemble Production LEGO Set
+      - name: 🏢 Build & Push Semantic Versioned LEGO Set
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -62,7 +72,8 @@ jobs:
           push: true
           tags: |
             maboni82/nextdns-optimized-analytics-${{ matrix.service }}:latest
-            maboni82/nextdns-optimized-analytics-${{ matrix.service }}:${{ env.tag }}
+            maboni82/nextdns-optimized-analytics-${{ matrix.service }}:${{ env.version }}
+            maboni82/nextdns-optimized-analytics-${{ matrix.service }}:${{ env.year_month }}
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Overview
This PR implements the new year/month-based semantic versioning system as outlined in #75, replacing the hardcoded v1.0.0 versioning with a dynamic YY.M.PATCH format.

## Changes Made

### Version Generation
- **Format**:  (e.g.,  for September 2025, build #123)
- **Date-based**: Year and month extracted from current date using 25.9  
- **Patch number**: Uses GitHub run number for automatic incrementing
- **Clean output**: Added detailed logging for version generation process

### Docker Tags Created
1. **** - Always updated for auto-updating systems
2. **** - Specific version (e.g., )
3. **** - Monthly rollup tag (e.g., )

### Workflow Updates
- Replaced problematic  logic
- Updated step names to reflect new semantic versioning
- Enhanced logging with emojis for better readability
- Maintained all existing functionality (multi-platform, caching, etc.)

## Example Output
For a build in September 2025 (run #123):
- Version: 
- Tags created:
  - 
  - 
  - 

## Benefits
✅ **Meaningful versions**: Can instantly identify when a build was created  
✅ **Auto-incrementing**: Each build gets the next patch number  
✅ **Consistent**: Same format for all builds  
✅ **Monthly rollups**: Easy to reference latest patch for a month  
✅ **Backwards compatible**: Maintains  tag  

## Testing
- Verified version generation logic locally
- Workflow syntax validated
- Example outputs confirmed to match requirements

## Future Enhancements
- Could query Docker Hub API for true patch number tracking
- Monthly release automation (separate PR coming)
- Build metadata integration

Fixes #75