### PR TITLE
🐛 Fix timeseries date offset issue - align timestamps with actual data periods

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -768,6 +768,17 @@ def get_stats_timeseries(profile_filter=None, time_range="24h", granularity="hou
         logger.debug(
             f"📊 Generated {len(data_points)} {granularity} time series data points for {time_range}"
         )
+        
+        # Debug: Log first and last data points to verify timestamp alignment
+        if data_points and granularity == "day":
+            first_point = data_points[0]
+            last_point = data_points[-1]
+            logger.debug(
+                f"🕐 First data point: {first_point['timestamp']} ({first_point['total_queries']} queries)"
+            )
+            logger.debug(
+                f"🕐 Last data point: {last_point['timestamp']} ({last_point['total_queries']} queries)"
+            )
         return data_points
 
     except SQLAlchemyError as e:

--- a/backend/models.py
+++ b/backend/models.py
@@ -741,13 +741,11 @@ def get_stats_timeseries(profile_filter=None, time_range="24h", granularity="hou
                         minute=0, second=0, microsecond=0
                     )
                 else:  # day
-                    # For daily granularity, use the end of the interval minus 1 day
-                    # This ensures the display date matches the actual data period
-                    # e.g., if interval_end is 2025-09-21, display as 2025-09-21 (not 2025-09-20)
-                    display_date = (interval_end - timedelta(days=1)).date()
-                    display_time = datetime.combine(
-                        display_date, datetime.min.time()
-                    ).replace(tzinfo=timezone.utc)
+                    # For daily granularity, use the start of the interval
+                    # Since we've aligned intervals to start of day, this gives correct dates
+                    display_time = interval_start.replace(
+                        hour=0, minute=0, second=0, microsecond=0
+                    )
 
             # Query for this interval
             interval_query = base_query.filter(

--- a/backend/models.py
+++ b/backend/models.py
@@ -702,14 +702,18 @@ def get_stats_timeseries(profile_filter=None, time_range="24h", granularity="hou
         elif time_range == "30d":
             # For daily data, align to start of today and work backwards
             today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-            start_time = today_start - timedelta(days=29)  # 29 days back + today = 30 days
+            start_time = today_start - timedelta(
+                days=29
+            )  # 29 days back + today = 30 days
             interval_hours = 24
             num_intervals = 30  # 30 x 1day = 30 days
             granularity = "day"
         else:  # 'all'
             # For 'all', we'll use daily intervals for the last 30 days
             today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-            start_time = today_start - timedelta(days=29)  # 29 days back + today = 30 days
+            start_time = today_start - timedelta(
+                days=29
+            )  # 29 days back + today = 30 days
             interval_hours = 24
             num_intervals = 30
             granularity = "day"
@@ -734,7 +738,7 @@ def get_stats_timeseries(profile_filter=None, time_range="24h", granularity="hou
             else:
                 interval_start = start_time + timedelta(hours=i * interval_hours)
                 interval_end = interval_start + timedelta(hours=interval_hours)
-                
+
                 if granularity == "hour":
                     # Round to exact hour for clean display
                     display_time = interval_start.replace(
@@ -768,7 +772,7 @@ def get_stats_timeseries(profile_filter=None, time_range="24h", granularity="hou
         logger.debug(
             f"📊 Generated {len(data_points)} {granularity} time series data points for {time_range}"
         )
-        
+
         # Debug: Log first and last data points to verify timestamp alignment
         if data_points and granularity == "day":
             first_point = data_points[0]


### PR DESCRIPTION
Fixes issue #73 where timeseries data was showing incorrect dates - today's data (Sept 21st) was being labeled with yesterday's timestamp (Sept 20th).

## Root Cause
The timeseries calculation was using a naive approach where start_time was calculated 30 days ago, creating a 1-day offset between display timestamps and actual data periods.

## Solution
- For daily data, align to start of today and work backwards
- Use today_start - timedelta(days=29) instead of now - timedelta(days=30)
- This ensures exactly 30 days: 29 days back + today = 30 days
- Added debug logging to verify timestamp alignment

## Testing
Verified with date calculation simulation - today's data now correctly shows as Sept 21st instead of Sept 20th.

## Impact
- 7d, 30d, and all time ranges now show correct dates
- Frontend charts will display accurate date labels
- No breaking changes to API interface

Fixes #73