### PR TITLE
feat: Add enhanced time range options for granular analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Just like building a LEGO masterpiece, we've crafted a solution that assembles N
 - **🔄 Local NextDNS Log Synchronization** – Securely fetch logs and store them locally, like collecting all the right LEGO pieces before starting your build
 - **📊 Interactive Web Dashboard** – Modern React-based interface that transforms raw data into visual insights, like seeing your LEGO creation from every angle
 - **🔍 Advanced Data Filtering** – Powerful filtering capabilities that go beyond NextDNS's standard UI, like sorting LEGO bricks by color, shape and size
+- **⏰ Flexible Time Range Analysis** – From 30-minute real-time monitoring to 6-month trend analysis with adaptive granularity
 - **🏷️ TLD Aggregation Analytics** – Group subdomains under parent domains (gateway.icloud.com → icloud.com) for higher-level insights
 - **📱 Device Usage Analytics** – Track DNS activity by device with exclusion support for better network monitoring
 - **📈 Time Series Data** – Comprehensive time-based analytics for trend analysis and pattern recognition

--- a/backend/main.py
+++ b/backend/main.py
@@ -456,11 +456,16 @@ async def get_stats():
 async def get_logs_statistics(
     profile: Optional[str] = Query(
         default=None, description="Filter statistics by specific profile ID"
-    )
+    ),
+    time_range: str = Query(
+        default="all", description="Time range: 30m, 1h, 6h, 24h, 7d, 30d, 3m, all"
+    ),
 ):
-    """Get statistics for DNS logs in the database, optionally filtered by profile."""
-    logger.debug(f"📊 API request for logs statistics (profile: '{profile}')")
-    stats = get_logs_stats(profile_filter=profile)
+    """Get statistics for DNS logs in the database, optionally filtered by profile and time range."""
+    logger.debug(
+        f"📊 API request for logs statistics (profile: '{profile}', time_range: '{time_range}')"
+    )
+    stats = get_logs_stats(profile_filter=profile, time_range=time_range)
     logger.info(f"📊 Returning stats: {stats}")
     return LogsStatsResponse(**stats)
 
@@ -479,6 +484,9 @@ async def get_dns_logs(  # pylint: disable=too-many-positional-arguments
     profile: Optional[str] = Query(
         default=None, description="Filter by specific profile ID"
     ),
+    time_range: str = Query(
+        default="all", description="Time range: 30m, 1h, 6h, 24h, 7d, 30d, 3m, all"
+    ),
     limit: int = Query(
         default=100, ge=1, le=10000, description="Maximum number of records to return"
     ),
@@ -491,12 +499,13 @@ async def get_dns_logs(  # pylint: disable=too-many-positional-arguments
     - **search**: Search query for domain names
     - **status**: Filter by status (all, blocked, allowed)
     - **profile**: Filter by specific profile ID
+    - **time_range**: Time range filter (30m, 1h, 6h, 24h, 7d, 30d, 3m, all)
     - **limit**: Maximum number of records to return (1-10000)
     - **offset**: Number of records to skip for pagination
     """
     logger.debug(
         f"📊 API request: exclude={exclude}, search='{search}', "
-        f"status={status}, profile='{profile}', limit={limit}, offset={offset}"
+        f"status={status}, profile='{profile}', time_range='{time_range}', limit={limit}, offset={offset}"
     )
 
     logs = get_logs(
@@ -504,6 +513,7 @@ async def get_dns_logs(  # pylint: disable=too-many-positional-arguments
         search_query=search,
         status_filter=status,
         profile_filter=profile,
+        time_range=time_range,
         limit=limit,
         offset=offset,
     )
@@ -567,7 +577,7 @@ async def get_stats_overview(
         default=None, description="Filter by specific profile ID"
     ),
     time_range: str = Query(
-        default="24h", description="Time range: 1h, 24h, 7d, 30d, all"
+        default="24h", description="Time range: 30m, 1h, 6h, 24h, 7d, 30d, 3m, all"
     ),
 ):
     """Get overview statistics for the dashboard."""
@@ -586,7 +596,7 @@ async def get_stats_timeseries(
         default=None, description="Filter by specific profile ID"
     ),
     time_range: str = Query(
-        default="24h", description="Time range: 1h, 24h, 7d, 30d, all"
+        default="24h", description="Time range: 30m, 1h, 6h, 24h, 7d, 30d, 3m, all"
     ),
     granularity: Optional[str] = Query(
         default=None,
@@ -601,10 +611,13 @@ async def get_stats_timeseries(
     # Auto-determine granularity based on time range
     if not granularity:
         granularity_map = {
+            "30m": "1min",
             "1h": "5min",
+            "6h": "15min",
             "24h": "hour",
             "7d": "day",
             "30d": "day",
+            "3m": "week",
             "all": "week",
         }
         granularity = granularity_map.get(time_range, "hour")
@@ -630,7 +643,7 @@ async def get_top_domains(
         default=None, description="Filter by specific profile ID"
     ),
     time_range: str = Query(
-        default="24h", description="Time range: 1h, 24h, 7d, 30d, all"
+        default="24h", description="Time range: 30m, 1h, 6h, 24h, 7d, 30d, 3m, all"
     ),
     limit: int = Query(
         default=10, ge=5, le=50, description="Number of top domains to return"
@@ -665,7 +678,7 @@ async def get_top_tlds(
         default=None, description="Filter by specific profile ID"
     ),
     time_range: str = Query(
-        default="24h", description="Time range: 1h, 24h, 7d, 30d, all"
+        default="24h", description="Time range: 30m, 1h, 6h, 24h, 7d, 30d, 3m, all"
     ),
     limit: int = Query(
         default=10, ge=5, le=50, description="Number of top TLDs to return"
@@ -700,7 +713,7 @@ async def get_device_stats(
         default=None, description="Filter by specific profile ID"
     ),
     time_range: str = Query(
-        default="24h", description="Time range: 1h, 24h, 7d, 30d, all"
+        default="24h", description="Time range: 30m, 1h, 6h, 24h, 7d, 30d, 3m, all"
     ),
     limit: int = Query(
         default=10, ge=5, le=50, description="Number of top devices to return"

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -23,9 +23,10 @@ The NextDNS web dashboard provides basic analytics, but lacks advanced filtering
 - **Smart deduplication** prevents duplicate records
 - **Error recovery** with automatic retry logic
 
-### **📊 Advanced Analytics**
+### **📈 Advanced Analytics**
 - **Domain exclusion filtering** (filter out noise like CDNs)
-- **Time-range queries** with flexible date filtering
+- **Flexible time-range analysis** with 8 ranges from 30m to 3m
+- **Adaptive granularity** (1min → 15min → hourly → weekly)
 - **Query type analysis** (A, AAAA, CNAME, MX, etc.)
 - **Block/Allow ratios** and trending analysis
 - **Device-specific insights** when available

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ Welcome to the comprehensive documentation for NextDNS Optimized Analytics - a r
 
 - **Real-time DNS Log Collection** from NextDNS API
 - **Advanced Filtering** beyond standard NextDNS capabilities
+- **Flexible Time Range Analysis** - 8 time ranges from 30m to 3m with adaptive granularity
 - **Docker-based Deployment** with health monitoring
 - **Interactive Web Dashboard** with real-time analytics
 - **RESTful API** with FastAPI and automatic documentation


### PR DESCRIPTION
- Add 3 new time range options: 30m, 6h, 3m with adaptive granularity
  - 30m: 1-minute granularity for real-time monitoring
  - 6h: 15-minute granularity for medium-term trends
  - 3m: weekly granularity for long-term analysis

Backend changes:
- Update all stats functions (overview, domains, tlds, devices) with new time ranges
- Add time_range support to get_logs() and get_logs_stats() functions
- Enhanced get_stats_timeseries() with proper granularity mapping
- Update all API endpoints with new time range parameter support

Documentation updates:
- Comprehensive API reference update with new time range options
- Added detailed time range table with use cases and granularity
- Updated all endpoint examples with new time ranges
- Enhanced README and docs with flexible time range analysis feature

Resolves #74: Additional time range options for more granular analysis
