### PR TITLE
🐛 Fix: Make blocked domains endpoint respect profile filter

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1027,7 +1027,7 @@ def get_top_domains(profile_filter=None, time_range="24h", limit=10):
             try:
                 # pylint: disable=not-callable
                 blocked_results = (
-                    session.query(DNSLog.domain, func.count(DNSLog.id).label("count"))
+                    query.with_entities(DNSLog.domain, func.count(DNSLog.id).label("count"))
                     .filter(DNSLog.blocked.is_(True))
                     .group_by(DNSLog.domain)
                     .order_by(func.count(DNSLog.id).desc())
@@ -1058,7 +1058,7 @@ def get_top_domains(profile_filter=None, time_range="24h", limit=10):
             try:
                 # pylint: disable=not-callable
                 allowed_results = (
-                    session.query(DNSLog.domain, func.count(DNSLog.id).label("count"))
+                    query.with_entities(DNSLog.domain, func.count(DNSLog.id).label("count"))
                     .filter(DNSLog.blocked.is_(False))
                     .group_by(DNSLog.domain)
                     .order_by(func.count(DNSLog.id).desc())

--- a/backend/models.py
+++ b/backend/models.py
@@ -1027,7 +1027,9 @@ def get_top_domains(profile_filter=None, time_range="24h", limit=10):
             try:
                 # pylint: disable=not-callable
                 blocked_results = (
-                    query.with_entities(DNSLog.domain, func.count(DNSLog.id).label("count"))
+                    query.with_entities(
+                        DNSLog.domain, func.count(DNSLog.id).label("count")
+                    )
                     .filter(DNSLog.blocked.is_(True))
                     .group_by(DNSLog.domain)
                     .order_by(func.count(DNSLog.id).desc())
@@ -1058,7 +1060,9 @@ def get_top_domains(profile_filter=None, time_range="24h", limit=10):
             try:
                 # pylint: disable=not-callable
                 allowed_results = (
-                    query.with_entities(DNSLog.domain, func.count(DNSLog.id).label("count"))
+                    query.with_entities(
+                        DNSLog.domain, func.count(DNSLog.id).label("count")
+                    )
                     .filter(DNSLog.blocked.is_(False))
                     .group_by(DNSLog.domain)
                     .order_by(func.count(DNSLog.id).desc())


### PR DESCRIPTION
## Description
The blocked domains endpoint (/stats/domains) wasn't properly applying profile filters, causing it to show the same results regardless of which profile was selected.

### Bug Fix
- Fixed get_top_domains function to properly apply profile and time range filters
- Updated both blocked and allowed domains queries to use the base query's filters
- Ensures that domain statistics are correctly filtered by profile

### Technical Details
Changed the query construction to use with_entities() on the filtered base query instead of creating new unfiltered queries. This ensures that all filters (profile, time range) are properly applied before aggregating the domain statistics.

### Testing
✅ Verified that different profile IDs now return different results:
```bash
curl -X 'GET' 'http://localhost:5001/stats/domains?profile=7982ec&time_range=24h&limit=10'
curl -X 'GET' 'http://localhost:5001/stats/domains?profile=c79ddb&time_range=24h&limit=10'
```

### Impact
- More accurate statistics when filtering by profile
- Better insights into profile-specific domain blocking
- No performance impact (uses same query optimization)

Fixes #102